### PR TITLE
Add Metrologia bibliographic parsing functionality

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,33 +30,56 @@ $ gem install niso-jats
 
 == Usage
 
-To parse a NISO JATS XML document:
+=== Parsing a NISO JATS XML document
 
 [source,ruby]
 ----
 require 'niso/jats'
 
-jats = Niso::Jats::Document.new(File.read('jats.xml'))
-puts jats.title
-puts jats.abstract
-puts jats.sections
+article = Niso::Jats::Article.from_xml(File.read('article.xml'))
 ----
 
-To generate a NISO JATS XML document:
+=== Extracting bibliographic data
+
+The `Article` class provides convenience methods for common lookups:
 
 [source,ruby]
 ----
-require 'niso/jats'
+article.journal_title   # => "Metrologia"
+article.doi             # => "10.1088/0026-1394/52/1/155"
 
-jats = Niso::Jats::Document.new
-jats.title = 'An Article Title'
-jats.abstract = 'An Article Abstract'
-jats.sections = [
-  Niso::Jats::Section.new('Section 1', 'This is the first section'),
-  Niso::Jats::Section.new('Section 2', 'This is the second section')
-]
+article.contributors
+# => [#<Niso::Jats::Contrib>, #<Niso::Jats::Contrib>, ...]
 
-puts jats.to_xml
+article.affiliation("aff1")
+# => [#<Niso::Jats::Aff>]
+
+article.pub_dates
+# => ["2015-02-01", "2015-01-30"]
+
+article.locality
+# => [["volume", "52"], ["issue", "1"], ["page", "155", "162"]]
+
+article.doi_links
+# => [{ content: "https://doi.org/10.1088/0026-1394/52/1/155", type: "src" },
+#     { content: "https://doi.org/10.1088/0026-1394/52/1/155", type: "doi" }]
+----
+
+=== Working with contributors
+
+The `Contrib` class provides filtering on cross-references:
+
+[source,ruby]
+----
+contrib = article.contributors.first
+contrib.aff_xrefs   # => [#<Niso::Jats::Xref ref_type="aff" rid="aff1">]
+----
+
+=== Generating a NISO JATS XML document
+
+[source,ruby]
+----
+puts article.to_xml(declaration: true, encoding: "utf-8")
 ----
 
 

--- a/lib/niso/jats/article.rb
+++ b/lib/niso/jats/article.rb
@@ -32,6 +32,112 @@ module Niso
         map_element "sub-article", to: :sub_article
         map_element "response", to: :response
       end
+
+      # Returns the first journal title from journal metadata.
+      #
+      # @return [String, nil] the journal title
+      def journal_title
+        meta = front&.journal_meta
+        return unless meta
+
+        titles = meta.journal_title_group.first.journal_title
+        titles.first.content if titles.any?
+      end
+
+      # Returns the DOI (Digital Object Identifier) from article identifiers.
+      #
+      # @return [String, nil] the DOI value
+      def doi
+        ids = front&.article_meta&.article_id
+        return unless ids
+
+        ids.find { |id| id.pub_id_type == "doi" }&.content
+      end
+
+      # Returns all contributors across all contrib-groups in article metadata.
+      #
+      # @return [Array<Contrib>] the flattened list of contributors
+      def contributors
+        groups = front&.article_meta&.contrib_group
+        return [] unless groups
+
+        groups.flat_map(&:contrib)
+      end
+
+      # Returns affiliations matching the given id across all contrib-groups.
+      #
+      # @param id [String] the affiliation id to match
+      # @return [Array<Aff>] matching affiliations
+      def affiliation(id)
+        groups = front&.article_meta&.contrib_group
+        return [] unless groups
+
+        groups.flat_map(&:aff).select { |a| a.id == id }
+      end
+
+      # Returns formatted publication dates as ISO 8601 strings (YYYY-MM-DD).
+      # Missing month or day defaults to "01".
+      #
+      # @return [Array<String>] formatted date strings
+      def pub_dates
+        dates = front&.article_meta&.pub_date
+        return [] unless dates
+
+        dates.map { |d| format_pub_date(d) }
+      end
+
+      # Returns bibliographic locality (volume, issue, page range).
+      #
+      # @return [Array<Array<String>>] each entry is [type, value] or
+      #   [type, from, to] for page ranges
+      def locality
+        meta = front&.article_meta
+        return [] unless meta
+
+        build_locality(meta)
+      end
+
+      # Returns DOI-based links derived from article identifiers.
+      #
+      # @return [Array<Hash{Symbol => String}>] each hash has :content (URL)
+      #   and :type ("src" or "doi")
+      def doi_links
+        ids = front&.article_meta&.article_id
+        return [] unless ids
+
+        ids.each_with_object([]) do |id, links|
+          next unless id.pub_id_type == "doi"
+
+          url = "https://doi.org/#{id.content}"
+          links << { content: url, type: "src" }
+          links << { content: url, type: "doi" }
+        end
+      end
+
+      private
+
+      def format_pub_date(pub_date)
+        year = pub_date.year&.content
+        month = pad_date_part(pub_date.month&.content)
+        day = pad_date_part(pub_date.day&.content)
+        "#{year}-#{month}-#{day}"
+      end
+
+      def pad_date_part(value)
+        return "01" if value.nil? || value.empty?
+
+        value.rjust(2, "0")
+      end
+
+      def build_locality(meta)
+        coll = meta.volume.map { |v| ["volume", v.content] }
+        meta.issue.each { |i| coll << ["issue", i.content] }
+        return coll unless meta.fpage
+
+        page = ["page", meta.fpage.content]
+        page << meta.lpage.content if meta.lpage
+        coll << page
+      end
     end
   end
 end

--- a/lib/niso/jats/contrib.rb
+++ b/lib/niso/jats/contrib.rb
@@ -63,6 +63,13 @@ module Niso
         map_element "uri", to: :uri
         map_element "xref", to: :xref
       end
+
+      # Returns cross-references to affiliations (ref-type "aff").
+      #
+      # @return [Array<Xref>] affiliation cross-references
+      def aff_xrefs
+        xref.select { |x| x.ref_type == "aff" }
+      end
     end
   end
 end

--- a/spec/fixtures/met_52_1_155.xml
+++ b/spec/fixtures/met_52_1_155.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article
+  PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML"
+  xmlns:xlink="http://www.w3.org/1999/xlink" article-type="note" dtd-version="1.1" xml:lang="en">
+  <front>
+    <journal-meta>
+      <journal-id journal-id-type="publisher-id">met</journal-id>
+      <journal-id journal-id-type="coden">MTRGAU</journal-id>
+      <journal-title-group>
+        <journal-title xml:lang="en">Metrologia</journal-title>
+        <abbrev-journal-title abbrev-type="IOP" xml:lang="en">MET</abbrev-journal-title>
+        <abbrev-journal-title abbrev-type="publisher" xml:lang="en">Metrologia</abbrev-journal-title>
+      </journal-title-group>
+      <issn pub-type="ppub">0026-1394</issn>
+      <issn pub-type="epub">1681-7575</issn>
+      <publisher>
+        <publisher-name>IOP Publishing</publisher-name>
+      </publisher>
+      <notes notes-type="publishing-partner">
+        <p>Bureau International des Poids et Mesures</p>
+      </notes>
+    </journal-meta>
+    <article-meta>
+      <article-id pub-id-type="publisher-id">met507496</article-id>
+      <article-id pub-id-type="doi">10.1088/0026-1394/52/1/155</article-id>
+      <article-id pub-id-type="manuscript">507496</article-id>
+      <article-categories>
+        <subj-group subj-group-type="display-article-type">
+          <subject>International Report</subject>
+        </subj-group>
+        <subj-group subj-group-type="section">
+          <subject>Other Editorial Matter</subject>
+        </subj-group>
+      </article-categories>
+      <title-group>
+        <article-title>News from the BIPM laboratories: 2014</article-title>
+
+      </title-group>
+      <contrib-group>
+        <contrib contrib-type="author" xlink:type="simple">
+          <name name-style="western">
+            <surname>Los Arcos</surname>
+            <given-names>José-Maria</given-names>
+          </name>
+          <xref ref-type="aff" rid="affiliation01">1</xref>
+        </contrib>
+        <contrib contrib-type="author" xlink:type="simple">
+          <name name-style="western">
+            <surname>Stock</surname>
+            <given-names>Michael</given-names>
+          </name>
+          <xref ref-type="aff" rid="affiliation01">1</xref>
+        </contrib>
+        <contrib contrib-type="author" xlink:type="simple">
+          <name name-style="western">
+            <surname>Wielgosz</surname>
+            <given-names>Robert</given-names>
+          </name>
+          <xref ref-type="aff" rid="affiliation01">1</xref>
+        </contrib>
+        <contrib contrib-type="author" xlink:type="simple">
+          <name name-style="western">
+            <surname>Arias</surname>
+            <given-names>Felicitas</given-names>
+          </name>
+          <xref ref-type="aff" rid="affiliation01">1</xref>
+        </contrib>
+        <contrib contrib-type="author" xlink:type="simple">
+          <name name-style="western">
+            <surname>Milton</surname>
+            <given-names>Martin</given-names>
+          </name>
+          <xref ref-type="aff" rid="affiliation01">1</xref>
+          <email>martin.milton@bipm.org</email>
+        </contrib>
+
+
+
+        <aff id="affiliation01">
+          <label>1</label>
+          <institution xlink:type="simple">Bureau International des Poids et Mesures (BIPM)</institution>, Pavillon de Breteuil, 92312 CEDEX, Sèvres, <country>France</country>
+        </aff>
+      </contrib-group>
+      <pub-date pub-type="ppub">
+        <day>01</day>
+        <month>2</month>
+        <year>2015</year>
+      </pub-date>
+      <pub-date pub-type="epub">
+        <day>30</day>
+        <month>1</month>
+        <year>2015</year>
+      </pub-date>
+      <volume>52</volume>
+      <issue>1</issue>
+      <fpage>155</fpage>
+      <lpage>162</lpage>
+      <history>
+        <date date-type="received">
+          <day>22</day>
+          <month>12</month>
+          <year>2014</year>
+        </date>
+        <date date-type="revised">
+          <day>22</day>
+          <month>12</month>
+          <year>2014</year>
+        </date>
+        <date date-type="accepted">
+          <day>22</day>
+          <month>12</month>
+          <year>2014</year>
+        </date>
+      </history>
+      <permissions>
+        <copyright-statement>© 2015 BIPM &amp; IOP Publishing Ltd</copyright-statement>
+        <copyright-year>2015</copyright-year>
+        <license license-type="iop-standard" xlink:href="https://publishingsupport.iopscience.iop.org/iop-standard/v1">
+          <license-p>This article is available under the terms of the <ext-link ext-link-type="uri">IOP-Standard License</ext-link>.
+          </license-p>
+        </license>
+      </permissions>
+      <self-uri content-type="pdf" xlink:href="met_52_1_155.pdf" xlink:type="simple"/>
+      <counts>
+        <page-count count="8"/>
+      </counts>
+      <custom-meta-group>
+        <custom-meta xlink:type="simple">
+          <meta-name>ccc</meta-name>
+          <meta-value>0026-1394/15/010155+08$33.00</meta-value>
+        </custom-meta>
+        <custom-meta xlink:type="simple">
+          <meta-name>printed</meta-name>
+          <meta-value>Printed in the UK</meta-value>
+        </custom-meta>
+        <custom-meta xlink:type="simple">
+          <meta-name>crossmark</meta-name>
+          <meta-value>yes</meta-value>
+        </custom-meta>
+      </custom-meta-group>
+    </article-meta>
+  </front>
+</article>

--- a/spec/fixtures/metv9i4p155.xml
+++ b/spec/fixtures/metv9i4p155.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article
+  PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML"
+  xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" xml:lang="en">
+  <front>
+    <journal-meta>
+      <journal-id journal-id-type="publisher-id">met</journal-id>
+      <journal-title-group>
+        <journal-title>Metrologia</journal-title>
+        <abbrev-journal-title abbrev-type="IOP">met</abbrev-journal-title>
+        <abbrev-journal-title abbrev-type="publisher">Metrologia</abbrev-journal-title>
+      </journal-title-group>
+      <issn pub-type="ppub">0026-1394</issn>
+      <issn pub-type="epub">1681-7575</issn>
+    </journal-meta>
+    <article-meta>
+      <article-id pub-id-type="publisher-id">0026-1394__</article-id>
+      <article-id pub-id-type="doi">10.1088/0026-1394/9/4/003</article-id>
+      <article-id pub-id-type="manuscript">003</article-id>
+      <article-categories>
+        <subj-group subj-group-type="display-article-type">
+          <subject/>
+        </subj-group>
+      </article-categories>
+      <title-group>
+        <article-title xml:lang="en">Volt Maintenance at NBS via 2<italic>e/h</italic>: A New Definition of the NBS Volt</article-title>
+      </title-group>
+      <contrib-group>
+        <contrib contrib-type="author" xlink:type="simple">
+          <name>
+            <surname>B F Field</surname>
+          </name>
+          <xref ref-type="aff" rid="aff1">1</xref>
+        </contrib>
+        <contrib contrib-type="author" xlink:type="simple">
+          <name>
+            <surname>T F Finnegan</surname>
+          </name>
+          <xref ref-type="aff" rid="aff1">1</xref>
+        </contrib>
+        <contrib contrib-type="author" xlink:type="simple">
+          <name>
+            <surname>J Toots</surname>
+          </name>
+          <xref ref-type="aff" rid="aff1">1</xref>
+        </contrib>
+        <aff id="aff1">
+          <label>1</label>Institute for Basic Standards, National Bureau of Standards, Washington, DC 20234, USA</aff>
+      </contrib-group>
+      <pub-date pub-type="ppub">
+        <day>01</day>
+        <month>10</month>
+        <year>1973</year>
+      </pub-date>
+      <volume>9</volume>
+      <issue>4</issue>
+      <fpage>155</fpage>
+      <lpage>166</lpage>
+      <history>
+        <date date-type="received">
+          <day>16</day>
+          <month>03</month>
+          <year>1973</year>
+        </date>
+      </history>
+      <permissions>
+        <copyright-statement>Published under licence by IOP Publishing Ltd</copyright-statement>
+        <copyright-year>1973</copyright-year>
+      </permissions>
+      <self-uri content-type="pdf" xlink:href="metv9i4p155.pdf" xlink:type="simple"/>
+      <abstract xml:lang="en">
+        <p>This paper describes in detail the procedures, methods and measurements used to establish a new definition of the U.S. legal volt via the ac Josephson effect. This new definition has been made possible by the use of thin film tunnel junctions (capable of producing 10 mV outputs) and high accuracy voltage comparators. The Josephson junction is used as a precise frequency-to-voltage converter with a conversion factor equal to 2<italic>e/h</italic>. A series of measurements of 2<italic>e/h</italic> has been carried out at NBS referenced to the as-maintained unit of emf based on a large group of standard cells. Measurements made at regular intervals over a one year period (1971 to 1972) indicate that the mean emf of this group of standard cells has decreased about 4 parts in 10<sup>7</sup>. Primarily to remove the effects of this drift, on July 1, 1972 a new as-maintained unit was defined by choosing a value of 2<italic>e/h</italic> consistent with the existing unit of emf. The adopted value of 2<italic>e/h</italic> is 483593.420 GHz/V<sub>NBS</sub>. The precision (one standard deviation) with which the new unit of emf can be maintained with the present techniques and apparatus is about 2 parts in 10<sup>8</sup>. The accuracy of the present system is estimated to be 4 parts in 10<sup>8</sup>. Comparisons of 2<italic>e/h</italic> systems at different national laboratories have been limited by uncertainties associated with the physical transfer of standard cells. In order to determine the relative agreement of the various 2<italic>e/h</italic> systems with precision better than 1 or 2 parts in 10<sup>7</sup>, it appears desirable to compare 2<italic>e/h</italic> systems directly by transporting one of them.</p>
+      </abstract>
+    </article-meta>
+  </front>
+</article>

--- a/spec/niso/jats/metrologia_spec.rb
+++ b/spec/niso/jats/metrologia_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+RSpec.describe Niso::Jats::Article do
+  describe "Metrologia JATS v1.1 parsing (met_52_1_155.xml)" do
+    subject { described_class.from_xml(file_fixture("met_52_1_155.xml").read) }
+
+    it "extracts the journal title" do
+      expect(subject.journal_title).to eq("Metrologia")
+    end
+
+    it "extracts the DOI" do
+      expect(subject.doi).to eq("10.1088/0026-1394/52/1/155")
+    end
+
+    it "extracts contributors" do
+      contribs = subject.contributors
+      expect(contribs.size).to eq(5)
+      expect(contribs.first.contrib_type).to eq("author")
+      expect(contribs.first.name.first.surname.content).to eq("Los Arcos")
+    end
+
+    it "looks up affiliations by id" do
+      affs = subject.affiliation("affiliation01")
+      expect(affs.size).to eq(1)
+      expect(affs.first.id).to eq("affiliation01")
+    end
+
+    it "extracts formatted publication dates" do
+      expect(subject.pub_dates).to eq(["2015-02-01", "2015-01-30"])
+    end
+
+    it "extracts locality (volume, issue, pages)" do
+      expect(subject.locality).to eq(
+        [
+          ["volume", "52"],
+          ["issue", "1"],
+          ["page", "155", "162"],
+        ],
+      )
+    end
+
+    it "extracts DOI links" do
+      url = "https://doi.org/10.1088/0026-1394/52/1/155"
+      expect(subject.doi_links).to eq(
+        [
+          { content: url, type: "src" },
+          { content: url, type: "doi" },
+        ],
+      )
+    end
+
+    it "returns contributor affiliation cross-references" do
+      xrefs = subject.contributors.first.aff_xrefs
+      expect(xrefs.size).to eq(1)
+      expect(xrefs.first.ref_type).to eq("aff")
+      expect(xrefs.first.rid).to eq("affiliation01")
+    end
+  end
+
+  describe "Metrologia JATS v1.1 parsing (metv9i4p155.xml)" do
+    subject { described_class.from_xml(file_fixture("metv9i4p155.xml").read) }
+
+    it "extracts the DOI" do
+      expect(subject.doi).to eq("10.1088/0026-1394/9/4/003")
+    end
+
+    it "extracts locality (volume, issue, pages)" do
+      expect(subject.locality).to eq(
+        [
+          ["volume", "9"],
+          ["issue", "4"],
+          ["page", "155", "166"],
+        ],
+      )
+    end
+  end
+end


### PR DESCRIPTION
Closes relaton/relaton-bipm#60

## Summary

Adds query methods directly on `Article` and `Contrib` for extracting common bibliographic data from parsed JATS XML, replacing the previous approach of separate `ArticleModel`/`ContribModel` classes.

### Changes

- **`Article` query methods**: `journal_title`, `doi`, `contributors`, `affiliation`, `pub_dates`, `locality`, `doi_links`
- **`Contrib` query method**: `aff_xrefs` — filters cross-references by `ref-type="aff"`
- **Metrologia JATS v1.1 fixture XMLs**: Two real-world fixtures from the Metrologia journal for testing
- **Specs**: 10 tests covering all query methods against both fixtures

### Design decisions

The original branch introduced separate `ArticleModel` and `ContribModel` classes wired via lutaml-model's `model` directive. Since the Metrologia XML is standard JATS (already fully supported by the existing model tree), the query methods are now instance methods directly on `Article` and `Contrib` — no extra classes, no `map_all` hacks that break round-trip fidelity.

### Test plan

- [x] All 14 specs pass (4 existing + 10 new)
- [x] Rubocop clean on all 323 files
- [x] Existing round-trip specs unaffected