### PR TITLE
fix: replace ordered + map_content with mixed_content + collection

### DIFF
--- a/lib/niso/jats/award_id.rb
+++ b/lib/niso/jats/award_id.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class AwardId < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :assigning_authority, :string
       attribute :award_id_type, :string
       attribute :award_type, :string
@@ -41,7 +41,7 @@ module Niso
 
       xml do
         element "award-id"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "assigning-authority", to: :assigning_authority

--- a/lib/niso/jats/chapter_title.rb
+++ b/lib/niso/jats/chapter_title.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class ChapterTitle < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :id, :string
       attribute :specific_use, :string
       attribute :lang, :xml_lang
@@ -40,7 +40,7 @@ module Niso
 
       xml do
         element "chapter-title"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "id", to: :id

--- a/lib/niso/jats/chem_struct.rb
+++ b/lib/niso/jats/chem_struct.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class ChemStruct < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :hreflang, :string
       attribute :id, :string
@@ -47,7 +47,7 @@ module Niso
 
       xml do
         element "chem-struct"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/code.rb
+++ b/lib/niso/jats/code.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Code < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :code_type, :string
       attribute :code_version, :string
       attribute :executable, :string
@@ -47,7 +47,7 @@ module Niso
 
       xml do
         element "code"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "code-type", to: :code_type

--- a/lib/niso/jats/collab.rb
+++ b/lib/niso/jats/collab.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Collab < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :collab_type, :string
       attribute :hreflang, :string
       attribute :id, :string
@@ -61,7 +61,7 @@ module Niso
 
       xml do
         element "collab"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "collab-type", to: :collab_type

--- a/lib/niso/jats/compound_kwd_part.rb
+++ b/lib/niso/jats/compound_kwd_part.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class CompoundKwdPart < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :bold, Bold, collection: true
@@ -33,7 +33,7 @@ module Niso
 
       xml do
         element "compound-kwd-part"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/compound_subject_part.rb
+++ b/lib/niso/jats/compound_subject_part.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class CompoundSubjectPart < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :bold, Bold, collection: true
@@ -30,7 +30,7 @@ module Niso
 
       xml do
         element "compound-subject-part"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/conf_loc.rb
+++ b/lib/niso/jats/conf_loc.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class ConfLoc < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -20,7 +20,7 @@ module Niso
 
       xml do
         element "conf-loc"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/conf_sponsor.rb
+++ b/lib/niso/jats/conf_sponsor.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class ConfSponsor < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -13,7 +13,7 @@ module Niso
 
       xml do
         element "conf-sponsor"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/conf_theme.rb
+++ b/lib/niso/jats/conf_theme.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class ConfTheme < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -37,7 +37,7 @@ module Niso
 
       xml do
         element "conf-theme"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/copyright_holder.rb
+++ b/lib/niso/jats/copyright_holder.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class CopyrightHolder < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -15,7 +15,7 @@ module Niso
 
       xml do
         element "copyright-holder"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/copyright_statement.rb
+++ b/lib/niso/jats/copyright_statement.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class CopyrightStatement < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -29,7 +29,7 @@ module Niso
 
       xml do
         element "copyright-statement"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/data_title.rb
+++ b/lib/niso/jats/data_title.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class DataTitle < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -32,7 +32,7 @@ module Niso
 
       xml do
         element "data-title"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/date_in_citation.rb
+++ b/lib/niso/jats/date_in_citation.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class DateInCitation < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :calendar, :string
       attribute :content_type, :string
       attribute :id, :string
@@ -18,7 +18,7 @@ module Niso
 
       xml do
         element "date-in-citation"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "calendar", to: :calendar

--- a/lib/niso/jats/event_desc.rb
+++ b/lib/niso/jats/event_desc.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class EventDesc < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :id, :string
       attribute :specific_use, :string
       attribute :lang, :xml_lang
@@ -24,7 +24,7 @@ module Niso
 
       xml do
         element "event-desc"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "id", to: :id

--- a/lib/niso/jats/funding_statement.rb
+++ b/lib/niso/jats/funding_statement.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class FundingStatement < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :id, :string
       attribute :rid, :string
       attribute :specific_use, :string
@@ -29,7 +29,7 @@ module Niso
 
       xml do
         element "funding-statement"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "id", to: :id

--- a/lib/niso/jats/gov.rb
+++ b/lib/niso/jats/gov.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Gov < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -26,7 +26,7 @@ module Niso
 
       xml do
         element "gov"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/inline_media.rb
+++ b/lib/niso/jats/inline_media.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class InlineMedia < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :hreflang, :string
       attribute :id, :string
@@ -38,7 +38,7 @@ module Niso
 
       xml do
         element "inline-media"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/inline_supplementary_material.rb
+++ b/lib/niso/jats/inline_supplementary_material.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class InlineSupplementaryMaterial < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :hreflang, :string
       attribute :id, :string
@@ -34,7 +34,7 @@ module Niso
 
       xml do
         element "inline-supplementary-material"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/institution.rb
+++ b/lib/niso/jats/institution.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Institution < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :hreflang, :string
       attribute :id, :string
@@ -15,7 +15,7 @@ module Niso
 
       xml do
         element "institution"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/kwd.rb
+++ b/lib/niso/jats/kwd.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Kwd < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :assigning_authority, :string
       attribute :content_type, :string
       attribute :id, :string
@@ -29,7 +29,7 @@ module Niso
 
       xml do
         element "kwd"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "assigning-authority", to: :assigning_authority

--- a/lib/niso/jats/label.rb
+++ b/lib/niso/jats/label.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Label < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :alt, :string
       attribute :id, :string
       attribute :lang, :xml_lang
@@ -29,7 +29,7 @@ module Niso
 
       xml do
         element "label"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "alt", to: :alt

--- a/lib/niso/jats/license_p.rb
+++ b/lib/niso/jats/license_p.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class LicenseP < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -84,7 +84,7 @@ module Niso
 
       xml do
         element "license-p"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/named_content.rb
+++ b/lib/niso/jats/named_content.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class NamedContent < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :alt, :string
       attribute :content_type, :string
       attribute :hreflang, :string
@@ -84,7 +84,7 @@ module Niso
 
       xml do
         element "named-content"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "alt", to: :alt

--- a/lib/niso/jats/on_behalf_of.rb
+++ b/lib/niso/jats/on_behalf_of.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class OnBehalfOf < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :id, :string
       attribute :specific_use, :string
       attribute :lang, :xml_lang
@@ -30,7 +30,7 @@ module Niso
 
       xml do
         element "on-behalf-of"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "id", to: :id

--- a/lib/niso/jats/part_title.rb
+++ b/lib/niso/jats/part_title.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class PartTitle < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :id, :string
       attribute :specific_use, :string
       attribute :lang, :xml_lang
@@ -40,7 +40,7 @@ module Niso
 
       xml do
         element "part-title"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "id", to: :id

--- a/lib/niso/jats/preformat.rb
+++ b/lib/niso/jats/preformat.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Preformat < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :id, :string
       attribute :orientation, :string, default: -> { "portrait" }
       attribute :position, :string, default: -> { "float" }
@@ -40,7 +40,7 @@ module Niso
 
       xml do
         element "preformat"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "id", to: :id

--- a/lib/niso/jats/price.rb
+++ b/lib/niso/jats/price.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Price < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :currency, :string
       attribute :id, :string
@@ -23,7 +23,7 @@ module Niso
 
       xml do
         element "price"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/principal_award_recipient.rb
+++ b/lib/niso/jats/principal_award_recipient.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class PrincipalAwardRecipient < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :id, :string
       attribute :specific_use, :string
       attribute :lang, :xml_lang
@@ -16,7 +16,7 @@ module Niso
 
       xml do
         element "principal-award-recipient"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "id", to: :id

--- a/lib/niso/jats/principal_investigator.rb
+++ b/lib/niso/jats/principal_investigator.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class PrincipalInvestigator < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :id, :string
       attribute :specific_use, :string
       attribute :lang, :xml_lang
@@ -14,7 +14,7 @@ module Niso
 
       xml do
         element "principal-investigator"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "id", to: :id

--- a/lib/niso/jats/product.rb
+++ b/lib/niso/jats/product.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Product < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :hreflang, :string
       attribute :id, :string
       attribute :product_type, :string
@@ -107,7 +107,7 @@ module Niso
 
       xml do
         element "product"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "hreflang", to: :hreflang

--- a/lib/niso/jats/publisher_loc.rb
+++ b/lib/niso/jats/publisher_loc.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class PublisherLoc < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :id, :string
       attribute :specific_use, :string
       attribute :lang, :xml_lang
@@ -22,7 +22,7 @@ module Niso
 
       xml do
         element "publisher-loc"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "id", to: :id

--- a/lib/niso/jats/publisher_name.rb
+++ b/lib/niso/jats/publisher_name.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class PublisherName < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :id, :string
       attribute :specific_use, :string
       attribute :lang, :xml_lang
@@ -12,7 +12,7 @@ module Niso
 
       xml do
         element "publisher-name"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "id", to: :id

--- a/lib/niso/jats/rb.rb
+++ b/lib/niso/jats/rb.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Rb < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -21,7 +21,7 @@ module Niso
 
       xml do
         element "rb"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/related_object.rb
+++ b/lib/niso/jats/related_object.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class RelatedObject < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :document_id, :string
       attribute :document_id_type, :string
@@ -97,7 +97,7 @@ module Niso
 
       xml do
         element "related-object"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/resource_name.rb
+++ b/lib/niso/jats/resource_name.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class ResourceName < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :hreflang, :string
       attribute :id, :string
@@ -24,7 +24,7 @@ module Niso
 
       xml do
         element "resource-name"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/role.rb
+++ b/lib/niso/jats/role.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Role < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :assigning_authority, :string
       attribute :content_type, :string
       attribute :degree_contribution, :string
@@ -32,7 +32,7 @@ module Niso
 
       xml do
         element "role"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "assigning-authority", to: :assigning_authority

--- a/lib/niso/jats/sans_serif.rb
+++ b/lib/niso/jats/sans_serif.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class SansSerif < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :id, :string
       attribute :specific_use, :string
       attribute :toggle, :string
@@ -48,7 +48,7 @@ module Niso
 
       xml do
         element "sans-serif"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "id", to: :id

--- a/lib/niso/jats/series.rb
+++ b/lib/niso/jats/series.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Series < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -26,7 +26,7 @@ module Niso
 
       xml do
         element "series"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/series_text.rb
+++ b/lib/niso/jats/series_text.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class SeriesText < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -26,7 +26,7 @@ module Niso
 
       xml do
         element "series-text"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/series_title.rb
+++ b/lib/niso/jats/series_title.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class SeriesTitle < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -26,7 +26,7 @@ module Niso
 
       xml do
         element "series-title"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/sig.rb
+++ b/lib/niso/jats/sig.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Sig < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :rid, :string
@@ -33,7 +33,7 @@ module Niso
 
       xml do
         element "sig"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/sig_block.rb
+++ b/lib/niso/jats/sig_block.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class SigBlock < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :rid, :string
@@ -34,7 +34,7 @@ module Niso
 
       xml do
         element "sig-block"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/source.rb
+++ b/lib/niso/jats/source.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Source < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -41,7 +41,7 @@ module Niso
 
       xml do
         element "source"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/speaker.rb
+++ b/lib/niso/jats/speaker.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Speaker < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -19,7 +19,7 @@ module Niso
 
       xml do
         element "speaker"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/std.rb
+++ b/lib/niso/jats/std.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Std < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -35,7 +35,7 @@ module Niso
 
       xml do
         element "std"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/std_organization.rb
+++ b/lib/niso/jats/std_organization.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class StdOrganization < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -15,7 +15,7 @@ module Niso
 
       xml do
         element "std-organization"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/string_conf.rb
+++ b/lib/niso/jats/string_conf.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class StringConf < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -45,7 +45,7 @@ module Niso
 
       xml do
         element "string-conf"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/string_date.rb
+++ b/lib/niso/jats/string_date.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class StringDate < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :calendar, :string
       attribute :content_type, :string
       attribute :id, :string
@@ -18,7 +18,7 @@ module Niso
 
       xml do
         element "string-date"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "calendar", to: :calendar

--- a/lib/niso/jats/styled_content.rb
+++ b/lib/niso/jats/styled_content.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class StyledContent < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :alt, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -81,7 +81,7 @@ module Niso
 
       xml do
         element "styled-content"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "alt", to: :alt

--- a/lib/niso/jats/subject.rb
+++ b/lib/niso/jats/subject.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Subject < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :assigning_authority, :string
       attribute :content_type, :string
       attribute :id, :string
@@ -35,7 +35,7 @@ module Niso
 
       xml do
         element "subject"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "assigning-authority", to: :assigning_authority

--- a/lib/niso/jats/supplement.rb
+++ b/lib/niso/jats/supplement.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Supplement < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :id, :string
       attribute :specific_use, :string
       attribute :supplement_type, :string
@@ -39,7 +39,7 @@ module Niso
 
       xml do
         element "supplement"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "id", to: :id

--- a/lib/niso/jats/support_source.rb
+++ b/lib/niso/jats/support_source.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class SupportSource < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :country, :string
       attribute :hreflang, :string
       attribute :id, :string
@@ -42,7 +42,7 @@ module Niso
 
       xml do
         element "support-source"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "country", to: :country

--- a/lib/niso/jats/target.rb
+++ b/lib/niso/jats/target.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Target < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :id, :string
       attribute :specific_use, :string
       attribute :target_type, :string
@@ -26,7 +26,7 @@ module Niso
 
       xml do
         element "target"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "id", to: :id

--- a/lib/niso/jats/trans_source.rb
+++ b/lib/niso/jats/trans_source.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class TransSource < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string
@@ -41,7 +41,7 @@ module Niso
 
       xml do
         element "trans-source"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/verse_line.rb
+++ b/lib/niso/jats/verse_line.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class VerseLine < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :indent_level, :string
@@ -44,7 +44,7 @@ module Niso
 
       xml do
         element "verse-line"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/version_element.rb
+++ b/lib/niso/jats/version_element.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class VersionElement < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :designator, :string
       attribute :id, :string
@@ -14,7 +14,7 @@ module Niso
 
       xml do
         element "version"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "content-type", to: :content_type

--- a/lib/niso/jats/xref.rb
+++ b/lib/niso/jats/xref.rb
@@ -3,7 +3,7 @@
 module Niso
   module Jats
     class Xref < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :alt, :string
       attribute :custom_type, :string
       attribute :id, :string
@@ -29,7 +29,7 @@ module Niso
 
       xml do
         element "xref"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "alt", to: :alt


### PR DESCRIPTION
## Summary

Update 58 models that used `ordered` + `map_content` to use `mixed_content` + `collection: true` instead.

These elements contain text interspersed with child elements (e.g., `<rb>text <bold>bold</bold> more</rb>`), which is mixed content in XSD terms. The `ordered` mode means element-only content and should not have `map_content`.

Required by lutaml/lutaml-model#676 which adds validation rejecting `ordered` + `map_content` as an invalid content model combination.

### Changes per model
- `attribute :content, :string` → `attribute :content, :string, collection: true`
- `ordered` → `mixed_content`

All 61 tests pass.