### PR TITLE
cimas sync 2026-08-10 wave (3-week drift catch-up + standoc-models P3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,21 +14,17 @@ on:
   repository_dispatch:
     types: [ do-release ]
 
+# Least-privilege ceiling for the called rubygems-release.yml: its release job
+# needs contents:write (git tag push) and id-token:write (OIDC Trusted Publishing).
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   release:
     uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
     with:
       next_version: ${{ github.event.inputs.next_version }}
-      # Explicit release_command needed since metanorma/ci#314 deprecated
-      # `bundler_cache` (hardcoded to false) — the reusable's release job no
-      # longer runs `bundle install` implicitly via ruby/setup-ruby, so the
-      # default `bundle exec rake release` fires against uninstalled gems.
-      # Surfaced by kwkwan on metanorma-plugin-lutaml#285. Deeper fix
-      # (bundle install inside rubygems-release.yml's release job) tracked
-      # separately.
-      release_command: |
-        bundle install
-        bundle exec rake release
     secrets:
       rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}


### PR DESCRIPTION
Fortnightly cimas sync wave 2026-08-10 (previous 2026-07-22, 3 weeks overdue).

## Wave-scale context

97 of 137 mapped repos have accumulated drift. Key changes this wave:

- **standoc-models P3** monorepo consolidation ([metanorma-core#16](https://github.com/metanorma/metanorma-core/issues/16) / [metanorma/ci#390](https://github.com/metanorma/ci/pull/390)): 16 `metanorma-model-*` entries collapsed into 1 `standoc-models` entry.
- **mn-samples-plateau docker.yml unmap** ([metanorma/ci#388](https://github.com/metanorma/ci/pull/388)): restored @strogonoff's local Firelight customizations after inadvertent cimas-sync strip on mn-samples-plateau#536.
- **ci#375/#376 supersedes** ([metanorma/ci#383](https://github.com/metanorma/ci/pull/383) / [#384](https://github.com/metanorma/ci/pull/384) / [#385](https://github.com/metanorma/ci/pull/385) landed 2026-08-07): reusable workflow shape updates.
- **gh-actions/model/Makefile verify-images defensive check** (ci#302 / #303): applied uniformly across model repos.
- **Various minor drift**: rubocop-todo inherit fix, release.yml bundle install fix (both from prior wave 2026-07-22).

## What to review on this repo

The branch diff shows what cimas synced from current templates. If any change is a clobbered opt-out (per-repo customization that shouldn't have been stripped), flag it and I'll unmap that file in cimas.yml — see the mn-samples-plateau#537 remediation pattern for the shape of the fix.

## Non-scope

- Individual template design changes (those go through their own PRs into metanorma/ci first).
- Wave-scale meta-issues (release scheduling, cadence): tracked via the metanorma/ci queue.

🤖
